### PR TITLE
parallax firefox fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -170,6 +170,15 @@
         this.onResize()
       }
     },
+    mounted () {
+      if (this.doParallax) {
+        // on firefox do a scroll to force rendering of parallax layers
+        var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1
+        if (isFirefox) {
+          document.getElementById('parallax_wrapper').scrollTop = 1
+        }
+      }
+    },
     destroyed () {
       window.removeEventListener('resize', this.onResize)
       document.body.removeEventListener('touchmove', this.onTouch)


### PR DESCRIPTION
add a micro scroll on firefox at load time to force rendering of all parallax layers