### PR TITLE
Smaller font in Techlologies section

### DIFF
--- a/src/Technologies.vue
+++ b/src/Technologies.vue
@@ -113,11 +113,10 @@
         :color #595959
     a
       :text-decoration none
-      :font-size large
+      :font-size 1em
       :margin-bottom 16px
       :text-transform uppercase
       :font-weight 300
-      :text-shadow 1px 1px 1px #bdbdbd
     h2
       :color #3ea5fd
       :text-align center


### PR DESCRIPTION
Font used in technologies section is too flashy. I made it smaller and removed a shadow. It's a bad practice to use shadows in flat design.