### PR TITLE
2.3.1 and 1.4.9 docs. Prune some older docs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
 
     <properties>
         <!-- main version properties -->
-        <docs.1.version>1.4.8</docs.1.version>
-        <docs.2.version>2.3.0</docs.2.version>
+        <docs.1.version>1.4.9</docs.1.version>
+        <docs.2.version>2.3.1</docs.2.version>
         <docs.latest.version>${docs.2.version}</docs.latest.version>
 
         <!-- Helidon archetypes version. Usually latest Helidon version.  -->
@@ -225,13 +225,7 @@
                                                 <variables>
                                                     <variable name="version">
                                                         <value>${docs.1.version}</value>
-                                                        <value>1.4.4</value>
-                                                        <value>1.4.3</value>
-                                                        <value>1.4.2</value>
-                                                        <value>1.4.1</value>
-                                                        <value>1.4.0</value>
                                                         <value>1.3.1</value>
-                                                        <value>1.3.0</value>
                                                         <value>1.2.1</value>
                                                         <value>1.1.2</value>
                                                         <value>1.0.3</value>
@@ -252,14 +246,10 @@
                                             <iterators>
                                                 <variables>
                                                     <variable name="version">
-                                                        <value>2.0.0</value>
-                                                        <value>2.0.1</value>
-                                                        <value>2.0.2</value>
-                                                        <value>2.1.0</value>
-                                                        <value>2.2.0</value>
-                                                        <value>2.2.1</value>
-                                                        <value>2.2.2</value>
                                                         <value>${docs.2.version}</value>
+                                                        <value>2.2.2</value>
+                                                        <value>2.1.0</value>
+                                                        <value>2.0.2</value>
                                                     </variable>
                                                 </variables>
                                             </iterators>


### PR DESCRIPTION
Updates docs for 2.3.1 and 1.4.9. Purges some older docs so we just keep the latest minor versions.